### PR TITLE
Fix mktemp crash that killed nightshift workers #300-302

### DIFF
--- a/nightshift/scripts/auto-dev.sh
+++ b/nightshift/scripts/auto-dev.sh
@@ -181,7 +181,7 @@ echo "$ISSUES" | jq -c '.[]' | while read -r issue; do
   EXECUTE_LOG="$LOG_DIR/${DATE}-${NUMBER}-execute.log"
 
   # Write prompt to temp file to avoid shell expansion of $BODY (security: prevents command injection)
-  EXECUTE_PROMPT=$(mktemp "$LOG_DIR/prompt-execute-XXXXXX.md")
+  EXECUTE_PROMPT=$(mktemp "$LOG_DIR/prompt-execute-XXXXXX")
   cat > "$EXECUTE_PROMPT" <<'PROMPT_HEADER'
 You are working on an issue in the target repo. Here is the full spec:
 
@@ -218,7 +218,7 @@ PROMPT_FOOTER
   SIMPLIFY_LOG="$LOG_DIR/${DATE}-${NUMBER}-simplify.log"
 
   # Write prompt to temp file (same security pattern as Phase 3)
-  SIMPLIFY_PROMPT=$(mktemp "$LOG_DIR/prompt-simplify-XXXXXX.md")
+  SIMPLIFY_PROMPT=$(mktemp "$LOG_DIR/prompt-simplify-XXXXXX")
   cat > "$SIMPLIFY_PROMPT" <<'PROMPT_HEADER'
 Review the code changes in this repo (git diff origin/main) against the original spec. Simplify for clarity, consistency, and maintainability. Preserve all functionality.
 


### PR DESCRIPTION
## Summary
- macOS BSD `mktemp` only randomizes `XXXXXX` when it's the **last** characters in the template
- The `.md` suffix after `XXXXXX` caused `mktemp` to create a literal file named `prompt-execute-XXXXXX.md` instead of a unique temp file
- Second worker to call `mktemp` got "File exists" → crash → circuit breaker tripped after 3 consecutive failures
- Fix: drop the `.md` extension from both `mktemp` calls (execute + simplify prompts) — these are ephemeral files deleted immediately after use

## Test plan
- [x] Verified `mktemp` without `.md` produces unique filenames across 3 rapid sequential calls
- [ ] Tonight's nightshift run should process CA registry issues (#300-302) without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)